### PR TITLE
Added support for Bear notes from different Bear apps (home <> Work)

### DIFF
--- a/bear_export_sync.py
+++ b/bear_export_sync.py
@@ -80,7 +80,6 @@ parser.add_argument("--backup", default=default_backup_folder, help="Path where 
 parser.add_argument("--images", default=None, help="Path where images will be stored")
 parser.add_argument("--skipImport", action="store_const", const=True, default=False, help="When present, the script only exports from Bear to Markdown; it skips the import step.")
 parser.add_argument("--excludeTag", action="append", default=[], help="Don't export notes with this tag. Can be used multiple times.")
-parser.add_argument("--init", action="store_const", const=True, default=False, help="Check the output folder for the first time and force all notes to be checked.")
 
 parsed_args = vars(parser.parse_args())
 


### PR DESCRIPTION
Added support for notes to be shared over multiple Bear accounts. 

My company allows me to have Bear installed, but only via the Companies "App Store". I'm not able to login to my personal Bear account or have a paid version of Bear. Until Bear releases the web version I have to sync my personal and work notes via this way.

To keep the Notes in sync, I manually change UUID from the newly created Note into the one found within the Notes content. While updating the note record, I update the content of the note without the `<!-- BearId: {uuid} -->`. Cause these changes are manually made on the SQLite database, Bear needs to be restarted to show all Notes properly. 

Tested 800+ notes, it took around a minute to create within Bear. All are successfully updated with there proper UUID. It can be verified by looking up the UUID found within the content of the note(in Dropbox or different) in the SQLite database. 