### PR TITLE
Changed DB Query to Skip Encrypted Notes

### DIFF
--- a/bear_export_sync.py
+++ b/bear_export_sync.py
@@ -163,7 +163,7 @@ def check_db_modified():
 def export_markdown():
     with sqlite3.connect(bear_db) as conn:
         conn.row_factory = sqlite3.Row
-        query = "SELECT * FROM `ZSFNOTE` WHERE `ZTRASHED` LIKE '0' AND `ZARCHIVED` LIKE '0'"
+        query = "SELECT * FROM `ZSFNOTE` WHERE `ZTRASHED` LIKE '0' AND `ZARCHIVED` LIKE '0' AND `ZENCRYPTED` LIKE '0'"
         c = conn.execute(query)
     note_count = 0
     for row in c:


### PR DESCRIPTION
If you have encrypted notes in Bear, the `bear_export_sync.py` script will fail and throw an exception.

```
Traceback (most recent call last):
 File "xxx/bear_export_sync.py", line 722, in <module>
  main()
 File "xxx/bear_export_sync.py", line 132, in main
  note_count = export_markdown()
 File "xxx/bear_export_sync.py", line 171, in export_markdown
  md_text = row['ZTEXT'].rstrip()
```


By changing the database query to ignore encrypted notes, I was able to run the script successfully.