### PR TITLE
Add '--exclude', '.obsidian' to RSync section to prevent overwriting

### DIFF
--- a/bear_export_sync.py
+++ b/bear_export_sync.py
@@ -440,6 +440,7 @@ def rsync_files_from_temp():
                              '--exclude', 'BearImages/',
                              '--exclude', '.Ulysses*',
                              '--exclude', '*.Ulysses_Public_Filter',
+                             '--exclude', '.obsidian',
                              temp_path + "/", dest_path])
         else:
             subprocess.call(['rsync', '-r', '-t', '-E',


### PR DESCRIPTION
Suggestion to add 
`'--exclude', '.obsidian'`
so that the invisible folder that Obsidian creates in the Bear Export folder when you add it as a Vault in Obsidian doesn't get overwritten. Obsidian stores all settings, themes, plugins and snippets in this folder.